### PR TITLE
Add very simple Hypothesis based tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,11 @@ except ImportError:
 
 
 # Python 2.6 does not have expectedFailre, unittest2 is a backport
-tests_require = []
+tests_require = ['hypothesis']
 try:
     from unittest.case import expectedFailure
 except ImportError:
-    tests_require = ['unittest2']
+    tests_require.append('unittest2')
 
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')


### PR DESCRIPTION
This is essentially a "getting started" test. All it does is assert
that the is_binary function should never crash regardless of what's
in the file.

There should be more interesting things to test here, but most of
the additional things I've tried fail and it's unclear that these
are really bugs so much as edge cases in the heuristic.

Note: This is the test that caught issue #12.