### PR TITLE
Add documentation status badge to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,10 @@ BinaryOrNot
 .. image:: https://travis-ci.org/audreyr/binaryornot.png?branch=master
         :target: https://travis-ci.org/audreyr/binaryornot
 
+.. image:: https://readthedocs.org/projects/binaryornot/badge/?version=latest
+        :target: https://readthedocs.org/projects/binaryornot/?badge=latest
+        :alt: Documentation Status
+
 
 Ultra-lightweight pure Python package to guess whether a file is binary or text,
 using a heuristic similar to Perl's `pp_fttext` and its analysis by @eliben.


### PR DESCRIPTION
I may be wrong, but I think the hook for ReadTheDocs is not set up. :no_mouth: 

Badge will work once the hook is set up!