### PR TITLE
Change test dependency management

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,10 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 setup(
     name='binaryornot',
     version='0.4.0',
-    description='Ultra-lightweight pure Python package to check if a file is binary or text.',
+    description=(
+        'Ultra-lightweight pure Python package to check '
+        'if a file is binary or text.'
+    ),
     long_description=readme + '\n\n' + history,
     author='Audrey Roy',
     author_email='audreyr@gmail.com',
@@ -42,7 +45,7 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,6 @@ except ImportError:
     from distutils.core import setup
 
 
-# Python 2.6 does not have expectedFailre, unittest2 is a backport
-tests_require = ['hypothesis']
-try:
-    from unittest.case import expectedFailure
-except ImportError:
-    tests_require.append('unittest2')
-
 readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
@@ -36,7 +29,6 @@ setup(
     install_requires=[
         'chardet>=2.0.0',
     ],
-    tests_require = tests_require,
     license="BSD",
     zip_safe=False,
     keywords='binaryornot',

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
     ],
     test_suite='tests',
 )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 
-import os
-import sys
-
-import binaryornot
 
 try:
     from setuptools import setup

--- a/tox.ini
+++ b/tox.ini
@@ -3,3 +3,9 @@ envlist = py26, py27, py33, py34, pypy
 
 [testenv]
 commands = python setup.py test
+deps = hypothesis
+
+
+[testenv:py26]
+deps = {[testenv]deps}
+       unittest2

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,4 @@
 envlist = py26, py27, py33, py34, pypy
 
 [testenv]
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/binaryornot
 commands = python setup.py test


### PR DESCRIPTION
Fix **flake8** violations in ``setup.py`` and move the requires for tests (``hypothesis`` and ``unittest2``) to ``tox.ini``.

Please let me know your thoughts! :bow: 