### PR TITLE
Don't crash if symlink points to nothing, treat it as binary

### DIFF
--- a/binaryornot/check.py
+++ b/binaryornot/check.py
@@ -9,6 +9,7 @@ Main code for checking if a file is binary or text.
 
 import logging
 
+import os
 from .helpers import get_starting_chunk, is_binary_string
 
 
@@ -29,5 +30,13 @@ def is_binary(filename):
             return True
 
     # Check if the starting chunk is a binary string
-    chunk = get_starting_chunk(filename)
-    return is_binary_string(chunk)
+    try:
+        if os.path.islink(filename) and not os.path.exists(filename):
+            return True
+        chunk = get_starting_chunk(filename)
+    except (OSError,IOError,ValueError,TypeError):
+        # rationale here is: we couldn't load the initial bit of content,
+        # so we'll have to treat this file as a binary file
+        return True 
+    else:
+        return is_binary_string(chunk)

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -203,6 +203,19 @@ class TestProgrammingArtifacts(unittest.TestCase):
     def test_binary_troublesome_pyc(self):
         self.assertTrue(is_binary('tests/files/troublesome.pyc'))
 
+class TestSymlinks(unittest.TestCase):
+    """Test that is_binary() doesn't crash when seeing symlinks"""
+    def setUp(self):
+        import tempfile
+        self.directory = tempfile.mkdtemp(prefix='binaryornot-',suffix='')
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.directory,True)
+    if hasattr(os,'symlink'):
+        def test_dangling_symlink(self):
+            target,symlink = os.path.join(self.directory,'missing'),os.path.join(self.directory,'link')
+            os.symlink('./missing',symlink)
+            self.assertTrue(is_binary(symlink))
 
 @contextmanager
 def bytes_in_file(data):


### PR DESCRIPTION
This enhancement prevents crashes if a cookiecutter happens to use a symlink that points to a location that doesn't exist on the running machine. It also treats errors when trying to read the initial chunk for binary testing as indicating a binary file (that second bit may be more controversial).