### PR TITLE
Tests: Avoid average_size argument in hypothesis

### DIFF
--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -216,7 +216,7 @@ def bytes_in_file(data):
 
 
 class TestDetectionProperties(unittest.TestCase):
-    @given(binary(average_size=512))
+    @given(binary())
     def test_never_crashes(self, data):
         with bytes_in_file(data) as f:
             is_binary(f)


### PR DESCRIPTION
The average_size argument was removed in Hypothesis 4.0.

See: https://hypothesis.readthedocs.io/en/latest/changes.html#v4-0-0