### PR TITLE
Remove short circuit for checking binary

### DIFF
--- a/binaryornot/check.py
+++ b/binaryornot/check.py
@@ -23,10 +23,10 @@ def is_binary(filename):
     logger.debug('is_binary: %(filename)r', locals())
 
     # Check if the file extension is in a list of known binary types
-    binary_extensions = ['.pyc', ]
-    for ext in binary_extensions:
-        if filename.endswith(ext):
-            return True
+#     binary_extensions = ['.pyc', ]
+#     for ext in binary_extensions:
+#         if filename.endswith(ext):
+#             return True
 
     # Check if the starting chunk is a binary string
     chunk = get_starting_chunk(filename)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,4 +5,4 @@ autopep8
 Sphinx
 coverage
 tox
-hypothesis==1.13.0
+hypothesis

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,4 +5,4 @@ autopep8
 Sphinx
 coverage
 tox
-hypothesis
+hypothesis==1.13.0

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -59,6 +59,10 @@ class TestIsBinary(unittest.TestCase):
 
     def test_binary_exe2(self):
         self.assertTrue(is_binary('tests/isBinaryFile/grep'))
+    
+    @expectedFailure
+    def test_negative_binary(self):
+        self.assertTrue(is_binary('tests/isBinaryFile/this_is_not_a_bin.pyc'))
 
 
 class TestFontFiles(unittest.TestCase):


### PR DESCRIPTION
There is a subtle bug introduced by short-circuiting the binary check. If a non-binary file is saved with a .pyc extension, it returns True. This case is not correct.