### PR TITLE
Replace chardet with charset-normalizer (MIT-licensed)

### DIFF
--- a/binaryornot/helpers.py
+++ b/binaryornot/helpers.py
@@ -8,7 +8,7 @@ binaryornot.helpers
 Helper utilities used by BinaryOrNot.
 """
 
-import chardet
+from charset_normalizer import detect as chardet_detect
 import logging
 
 
@@ -93,13 +93,21 @@ def is_binary_string(bytes_to_check):
     )
     logger.debug('is_likely_binary: %(is_likely_binary)r', locals())
 
-    # then check for binary for possible encoding detection with chardet
-    detected_encoding = chardet.detect(bytes_to_check)
+    # If heuristics strongly suggest binary, trust them. charset-normalizer
+    # is more aggressive than chardet at finding encodings for arbitrary byte
+    # sequences (any single-byte encoding can decode anything), so we don't
+    # let encoding detection override a strong binary signal.
+    if is_likely_binary:
+        return True
+
+    # For files that don't look obviously binary, check encoding detection
+    # to avoid false positives on non-Latin text files (CJK, Cyrillic, etc.)
+    detected_encoding = chardet_detect(bytes_to_check)
     logger.debug('detected_encoding: %(detected_encoding)r', locals())
 
-    # finally use all the check to decide binary or text
     decodable_as_unicode = False
-    if (detected_encoding['confidence'] > 0.9 and
+    if (detected_encoding['confidence'] is not None and
+            detected_encoding['confidence'] > 0.9 and
             detected_encoding['encoding'] != 'ascii'):
         try:
             try:
@@ -117,19 +125,10 @@ def is_binary_string(bytes_to_check):
             logger.debug('failure: decodable_as_unicode: '
                          '%(decodable_as_unicode)r', locals())
 
-    logger.debug('failure: decodable_as_unicode: '
-                 '%(decodable_as_unicode)r', locals())
-    if is_likely_binary:
-        if decodable_as_unicode:
-            return False
-        else:
-            return True
-    else:
-        if decodable_as_unicode:
-            return False
-        else:
-            if b'\x00' in bytes_to_check or b'\xff' in bytes_to_check:
-                # Check for NULL bytes last
-                logger.debug('has nulls:' + repr(b'\x00' in bytes_to_check))
-                return True
+    logger.debug('decodable_as_unicode: %(decodable_as_unicode)r', locals())
+    if decodable_as_unicode:
         return False
+    if b'\x00' in bytes_to_check or b'\xff' in bytes_to_check:
+        logger.debug('has nulls:' + repr(b'\x00' in bytes_to_check))
+        return True
+    return False

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     package_dir={'binaryornot': 'binaryornot'},
     include_package_data=True,
     install_requires=[
-        'chardet>=3.0.2',
+        'charset-normalizer>=2.0.0',
     ],
     license="BSD",
     zip_safe=False,


### PR DESCRIPTION
## Summary

- Replace `chardet` dependency with `charset-normalizer` to resolve licensing ambiguity
- `charset-normalizer` is MIT-licensed, actively maintained, and the standard replacement (used by `requests` since 2021)
- All 46 tests pass with identical results (46 passed, 2 xfailed)

## Why

chardet's licensing is complicated. The original code is LGPL (a port of Mozilla's C++ detector). The recent v7 rewrite claims MIT, but the original author [contests the relicensing](https://github.com/chardet/chardet/issues/327). `charset-normalizer` is unambiguously MIT and provides a compatible `detect()` API.

## What changed

**`setup.py`**: `chardet>=3.0.2` → `charset-normalizer>=2.0.0`

**`binaryornot/helpers.py`**:
- Import `detect` from `charset_normalizer` instead of `chardet`
- Handle `None` confidence (charset-normalizer returns `None` when it can't determine any encoding, while chardet returned low floats)
- Trust byte-ratio heuristics when `is_likely_binary` is `True`, instead of letting encoding detection override. charset-normalizer is more aggressive at finding encodings for arbitrary byte sequences (single-byte encodings like cp037 or cp1125 can decode literally anything with 1.0 confidence). No legitimate text file in the test suite triggers `is_likely_binary` — even CJK files have enough ASCII content to stay below the threshold — so the override was only producing false positives on binary data.

## Test plan

- [x] All 46 existing tests pass (46 passed, 2 xfailed, matching chardet baseline)
- [x] Verified all CJK/Cyrillic/Latin encoding test files are unaffected (none trigger `is_likely_binary`)
- [x] Verified the 3 files that charset-normalizer misclassified (decoding-error, lookup-error, pixelstream.rgb) now pass
- [x] Hypothesis fuzz test (`test_never_crashes`) passes