### PR TITLE
Type the public API

### DIFF
--- a/src/binaryornot/check.py
+++ b/src/binaryornot/check.py
@@ -7,13 +7,14 @@ Main code for checking if a file is binary or text.
 
 import argparse
 import logging
+from pathlib import Path
 
 from binaryornot.helpers import get_starting_chunk, is_binary_string
 
 logger = logging.getLogger(__name__)
 
 
-def is_binary(filename):
+def is_binary(filename: str | bytes | Path) -> bool:
     """
     :param filename: File to check.
     :returns: True if it's a binary file, otherwise False.
@@ -31,7 +32,7 @@ def is_binary(filename):
     return is_binary_string(chunk)
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Check if a file passed as argument is binary or not")
 
     parser.add_argument(

--- a/src/binaryornot/helpers.py
+++ b/src/binaryornot/helpers.py
@@ -7,20 +7,21 @@ Helper utilities used by BinaryOrNot.
 
 import logging
 import math
+from pathlib import Path
 
 from binaryornot.tree import is_binary as _is_binary_by_features
 
 logger = logging.getLogger(__name__)
 
 
-def print_as_hex(s):
+def print_as_hex(s: str) -> None:
     """
     Print a string as hex bytes.
     """
     print(":".join(f"{ord(c):x}" for c in s))
 
 
-def get_starting_chunk(filename, length=128):
+def get_starting_chunk(filename: str | bytes | Path, length: int = 128) -> bytes:
     """
     :param filename: File to open and get the first little chunk of.
     :param length: Number of bytes to read, default 128.
@@ -36,7 +37,7 @@ def get_starting_chunk(filename, length=128):
 _CONTROL_BYTES = frozenset(range(0, 32)) - {9, 10, 13}
 
 
-def _compute_features(chunk):
+def _compute_features(chunk: bytes) -> list[float]:
     """Compute features for the binary/text decision tree.
 
     Feature indices:
@@ -178,7 +179,7 @@ def _compute_features(chunk):
     ]
 
 
-def is_binary_string(bytes_to_check):
+def is_binary_string(bytes_to_check: bytes) -> bool:
     """
     Check if a chunk of bytes appears to be binary or text.
 

--- a/src/binaryornot/tree.py
+++ b/src/binaryornot/tree.py
@@ -5,7 +5,7 @@ Do not edit by hand. Regenerate with:
 """
 
 
-def is_binary(features):
+def is_binary(features: list[float]) -> bool:
     """Classify a byte chunk as binary or text.
 
     Takes the feature list from helpers._compute_features().


### PR DESCRIPTION
## Summary

- Inline type annotations on all public functions: `is_binary()`, `is_binary_string()`, `get_starting_chunk()`, plus internal `_compute_features()` and the decision tree's `is_binary()`
- `is_binary()` and `get_starting_chunk()` accept `str | bytes | Path`, matching what `open()` already handles
- Inline annotations instead of `.pyi` stubs since the project is Python 3.12+

Resolves #626. Supersedes #627. Addresses #628.

Credit to @smheidrich for #627 which first proposed `py.typed` and type stubs, and to @AlJohri for #628 requesting pathlib.Path support.

## Test plan

- [x] `uv run ty check` passes
- [x] `uv run ruff check` passes
- [x] `uv run pytest` passes (213 passed, 5 xfailed)
- No code changes, only annotations added