### PR TITLE
Tie feature labels to variable names so they can't silently drift (uses 3.12 and 3.14)

### DIFF
--- a/src/binaryornot/check.py
+++ b/src/binaryornot/check.py
@@ -7,31 +7,25 @@ Main code for checking if a file is binary or text.
 
 import argparse
 import logging
+from pathlib import Path
 
 from binaryornot.helpers import get_starting_chunk, is_binary_string
 
 logger = logging.getLogger(__name__)
 
 
-def is_binary(filename):
+def is_binary(filename: str | bytes | Path) -> bool:
     """
     :param filename: File to check.
     :returns: True if it's a binary file, otherwise False.
     """
     logger.debug("is_binary: %(filename)r", locals())
 
-    # Check if the file extension is in a list of known binary types
-    #     binary_extensions = ['.pyc', ]
-    #     for ext in binary_extensions:
-    #         if filename.endswith(ext):
-    #             return True
-
-    # Check if the starting chunk is a binary string
     chunk = get_starting_chunk(filename)
     return is_binary_string(chunk)
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Check if a file passed as argument is binary or not")
 
     parser.add_argument(

--- a/src/binaryornot/helpers.py
+++ b/src/binaryornot/helpers.py
@@ -7,26 +7,37 @@ Helper utilities used by BinaryOrNot.
 
 import logging
 import math
+from pathlib import Path
+from string.templatelib import Template
 
 from binaryornot.tree import is_binary as _is_binary_by_features
 
 logger = logging.getLogger(__name__)
 
+type FeatureVector = list[float]
 
-def print_as_hex(s):
+
+def _render_features(template: Template) -> str:
+    """Render a template string of feature values as name=value pairs."""
+    parts = []
+    for interpolation in template.interpolations:
+        parts.append(f"{interpolation.expression}={interpolation.value:.3f}")
+    return ", ".join(parts)
+
+
+def print_as_hex(s: str) -> None:
     """
     Print a string as hex bytes.
     """
     print(":".join(f"{ord(c):x}" for c in s))
 
 
-def get_starting_chunk(filename, length=128):
+def get_starting_chunk(filename: str | bytes | Path, length: int = 128) -> bytes:
     """
     :param filename: File to open and get the first little chunk of.
     :param length: Number of bytes to read, default 128.
     :returns: Starting chunk of bytes.
     """
-    # Ensure we open the file in binary mode
     with open(filename, "rb") as f:
         chunk = f.read(length)
         return chunk
@@ -36,30 +47,8 @@ def get_starting_chunk(filename, length=128):
 _CONTROL_BYTES = frozenset(range(0, 32)) - {9, 10, 13}
 
 
-def _compute_features(chunk):
-    """Compute features for the binary/text decision tree.
-
-    Feature indices:
-      0: null_ratio           - fraction of 0x00 bytes
-      1: control_ratio        - fraction of control chars (0x01-0x08, 0x0E-0x1F)
-      2: printable_ascii_ratio - fraction of 0x20-0x7E
-      3: high_byte_ratio      - fraction of 0x80-0xFF
-      4: utf8_valid           - 1.0 if chunk decodes as UTF-8
-      5: even_null_ratio      - fraction of even-index bytes that are 0x00
-      6: odd_null_ratio       - fraction of odd-index bytes that are 0x00
-      7: byte_entropy         - Shannon entropy of byte distribution
-      8-12: BOM flags         - UTF-32 LE/BE, UTF-16 LE/BE, UTF-8 BOM
-      13: try_utf16le         - 1.0 if chunk decodes as UTF-16-LE
-      14: try_utf16be         - 1.0 if chunk decodes as UTF-16-BE
-      15: try_utf32le         - 1.0 if chunk decodes as UTF-32-LE
-      16: try_utf32be         - 1.0 if chunk decodes as UTF-32-BE
-      17: longest_printable_run - longest run of printable chars / length
-      18: try_gb2312          - 1.0 if chunk decodes as GB2312
-      19: try_big5            - 1.0 if chunk decodes as Big5
-      20: try_shift_jis       - 1.0 if chunk decodes as Shift-JIS
-      21: try_euc_jp          - 1.0 if chunk decodes as EUC-JP
-      22: try_euc_kr          - 1.0 if chunk decodes as EUC-KR
-    """
+def _compute_features(chunk: bytes) -> FeatureVector:
+    """Compute 23 features from a byte chunk for the binary/text decision tree."""
     n = len(chunk)
 
     null_count = chunk.count(0)
@@ -138,7 +127,7 @@ def _compute_features(chunk):
             current_run = 0
     longest_printable_run = max_run / n
 
-    def _try_decode(encoding):
+    def _try_decode(encoding: str) -> float:
         try:
             chunk.decode(encoding)
             return 1.0
@@ -178,7 +167,7 @@ def _compute_features(chunk):
     ]
 
 
-def is_binary_string(bytes_to_check):
+def is_binary_string(bytes_to_check: bytes) -> bool:
     """
     Check if a chunk of bytes appears to be binary or text.
 
@@ -192,40 +181,21 @@ def is_binary_string(bytes_to_check):
         return False
 
     features = _compute_features(bytes_to_check)
+    [
+        null, ctrl, ascii_, high, utf8, even0, odd0, entropy,
+        bom32le, bom32be, bom16le, bom16be, bom8,
+        try16le, try16be, try32le, try32be,
+        run, gb2312, big5, shiftjis, eucjp, euckr,
+    ] = features
     result = _is_binary_by_features(features)
     logger.debug(
-        "is_binary_string: %r (features=%r)",
+        "is_binary_string: %r (%s)",
         result,
-        dict(
-            zip(
-                [
-                    "null",
-                    "ctrl",
-                    "ascii",
-                    "high",
-                    "utf8",
-                    "even0",
-                    "odd0",
-                    "entropy",
-                    "bom32le",
-                    "bom32be",
-                    "bom16le",
-                    "bom16be",
-                    "bom8",
-                    "try16le",
-                    "try16be",
-                    "try32le",
-                    "try32be",
-                    "run",
-                    "gb2312",
-                    "big5",
-                    "shiftjis",
-                    "eucjp",
-                    "euckr",
-                ],
-                [f"{v:.3f}" for v in features],
-                strict=True,
-            )
+        _render_features(
+            t"{null} {ctrl} {ascii_} {high} {utf8} {even0} {odd0} {entropy} "
+            t"{bom32le} {bom32be} {bom16le} {bom16be} {bom8} "
+            t"{try16le} {try16be} {try32le} {try32be} "
+            t"{run} {gb2312} {big5} {shiftjis} {eucjp} {euckr}"
         ),
     )
     return result

--- a/src/binaryornot/tree.py
+++ b/src/binaryornot/tree.py
@@ -4,8 +4,13 @@ Do not edit by hand. Regenerate with:
     uv run --with 'scikit-learn,numpy,hypothesis' python scripts/train_detector.py
 """
 
+from typing import TYPE_CHECKING
 
-def is_binary(features):
+if TYPE_CHECKING:
+    from binaryornot.helpers import FeatureVector
+
+
+def is_binary(features: FeatureVector) -> bool:
     """Classify a byte chunk as binary or text.
 
     Takes the feature list from helpers._compute_features().


### PR DESCRIPTION
Feature labels are now variable names. The 23-element feature vector is destructured into named variables, and a Python 3.14 template string passes them to _render_features(). The function walks the template interpolations and emits name=value pairs using each interpolation's .expression attribute. There is no separate name list to maintain, so labels can't go stale when features are added or reordered.

Key design decisions:
- type FeatureVector = list[float] (Python 3.12) gives the feature vector a first-class name in the type system
- Native str | bytes | Path union syntax for public API signatures
- tree.py imports FeatureVector under TYPE_CHECKING to avoid circular imports at runtime
- The 23-line feature index docstring in _compute_features is removed; the destructuring assignment is the index

Requires Python 3.14+ for t-strings. Putting this on hold for now; currently considering the support-python-310 branch to serve cookieplone users who need the older floor.