### PR TITLE
Ship .pyc and .DS_Store test fixtures in the sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,12 @@ exclude_also = [
     "\\.\\.\\.",
 ]
 
+[tool.hatch.build.targets.sdist.force-include]
+"tests/files/.DS_Store" = "tests/files/.DS_Store"
+"tests/files/empty.pyc" = "tests/files/empty.pyc"
+"tests/files/hello_world.pyc" = "tests/files/hello_world.pyc"
+"tests/files/troublesome.pyc" = "tests/files/troublesome.pyc"
+
 [tool.uv]
 package = true
 default-groups = ["dev"]

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -1,0 +1,37 @@
+"""Verify that test fixtures are included in the sdist."""
+
+import subprocess
+import tarfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestSdistContents(unittest.TestCase):
+    def test_sdist_includes_pyc_fixtures(self):
+        """The .pyc test fixtures must survive hatchling's sdist build."""
+        result = subprocess.run(
+            ["uv", "build", "--sdist", "--out-dir", "dist"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        sdists = sorted(ROOT.glob("dist/*.tar.gz"))
+        self.assertTrue(sdists, "No sdist found in dist/")
+        sdist_path = sdists[-1]
+
+        with tarfile.open(sdist_path) as tar:
+            names = tar.getnames()
+
+        expected = [
+            "tests/files/.DS_Store",
+            "tests/files/empty.pyc",
+            "tests/files/hello_world.pyc",
+            "tests/files/troublesome.pyc",
+        ]
+        for fixture in expected:
+            matching = [n for n in names if n.endswith(fixture)]
+            self.assertTrue(matching, f"{fixture} not found in sdist")


### PR DESCRIPTION
## Summary

Hatchling excludes .DS_Store via a hardcoded constant in
`hatchling/builders/constants.py` and .pyc files via
.gitignore's `*.py[codz]` glob. Both are test fixtures
that need to be in the archive for tests to pass when
run from the sdist.

`force-include` in pyproject.toml overrides both exclusion
mechanisms. A new test builds the sdist and verifies all
four fixtures are present.

Closes #641.

## Test plan

- [x] `test_sdist_includes_pyc_fixtures` fails without the fix (red)
- [x] `test_sdist_includes_pyc_fixtures` passes with the fix (green)
- [x] Full test suite passes (213 tests)